### PR TITLE
Logout SSO Fix: Missing path to RainLoop

### DIFF
--- a/build/owncloud/rainloop-app/lib/RainLoopHelper.php
+++ b/build/owncloud/rainloop-app/lib/RainLoopHelper.php
@@ -33,7 +33,7 @@ class OC_RainLoop_Helper
 	 *
 	 * @return boolean
 	 */
-	public static function clearUserSsoHash($sSsoHash)
+	public static function clearUserSsoHash($sPath, $sSsoHash)
 	{
 		$result = false;
 
@@ -119,7 +119,8 @@ class OC_RainLoop_Helper
 		$b = OCP\Config::setUserValue($sUser, 'rainloop', 'rainloop-ssohash', null);
 
 		if('' !== $sSsoHash) {
-			self::clearUserSsoHash($sSsoHash);
+			$sPath = trim(OCP\Config::getAppValue('rainloop', 'rainloop-path', ''));
+			self::clearUserSsoHash($sPath, $sSsoHash);
 		}
 
 		return $a && $b;


### PR DESCRIPTION
Apologies, I some how missed out the path to RainLoop parameter in the `clearUserSsoHash` function.
