### PR TITLE
fail2ban needs date in timestamp of log file entries to work properly

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/MailSo/Log/Driver.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Log/Driver.php
@@ -82,14 +82,14 @@ abstract class Driver
 	 */
 	protected function __construct()
 	{
-		$this->sDatePattern = 'H:i:s';
+		$this->sDatePattern = 'Y-m-d H:i:s';
 		$this->sName = 'INFO';
 		$this->sNewLine = "\r\n";
 		$this->bTimePrefix = true;
 		$this->bTypedPrefix = true;
 		$this->bGuidPrefix = true;
 
-		$this->iTimeOffset = 0;
+		$this->iTimeOffset = 2;
 
 		$this->iWriteOnTimeoutOnly = 0;
 		$this->bWriteOnErrorOnly = false;


### PR DESCRIPTION
Dear rainloop,

the library MailSo:Log:Driver logs the timestamp in the format **H:i:s** into the fail2ban log file.
Timestamps that are understood by fail2ban contain the date, as fail2ban monitors the entries of logfiles.

Although the file name of the log file itself written by rainloop contains the date, this does not work with fail2ban.

I created this pull request with a change that sets the format to **Y-m-d H:i:s** and works with fail2ban.

My system is on UTC +2, so I had to set `iTimeOffset` to 2, to get correct timestamps on my system.
Is there a better way to get the library initialized depending on the system rainloop is installed on?

Thanks,
Ralph