### PR TITLE
Adds support for customization of name shown in upper right

### DIFF
--- a/dev/Settings/User/General.js
+++ b/dev/Settings/User/General.js
@@ -34,6 +34,7 @@
 		this.messagesPerPageArray = Consts.Defaults.MessagesPerPageArray;
 
 		this.editorDefaultType = SettingsStore.editorDefaultType;
+		this.displayName = SettingsStore.displayName;
 		this.layout = SettingsStore.layout;
 		this.usePreviewPane = SettingsStore.usePreviewPane;
 
@@ -60,6 +61,7 @@
 		this.mppTrigger = ko.observable(Enums.SaveSettingsStep.Idle);
 		this.editorDefaultTypeTrigger = ko.observable(Enums.SaveSettingsStep.Idle);
 		this.layoutTrigger = ko.observable(Enums.SaveSettingsStep.Idle);
+		this.displayNameTrigger = ko.observable(Enums.SaveSettingsStep.Idle);
 
 		this.isAnimationSupported = Globals.bAnimationSupported;
 
@@ -121,6 +123,7 @@
 				f0 = Utils.settingsSaveHelperSimpleFunction(self.editorDefaultTypeTrigger, self),
 				f1 = Utils.settingsSaveHelperSimpleFunction(self.mppTrigger, self),
 				f2 = Utils.settingsSaveHelperSimpleFunction(self.layoutTrigger, self),
+				f3 = Utils.settingsSaveHelperSimpleFunction(self.displayNameTrigger, self),
 				fReloadLanguageHelper = function (iSaveSettingsStep) {
 					return function() {
 						self.languageTrigger(iSaveSettingsStep);
@@ -147,6 +150,12 @@
 			self.editorDefaultType.subscribe(function (sValue) {
 				Remote.saveSettings(f0, {
 					'EditorDefaultType': sValue
+				});
+			});
+
+			self.displayName.subscribe(function (sValue) {
+				Remote.saveSettings(f3, {
+					'DisplayName': sValue
 				});
 			});
 

--- a/dev/Stores/User/Settings.js
+++ b/dev/Stores/User/Settings.js
@@ -43,7 +43,7 @@
 		this.replySameFolder = ko.observable(false);
 
 		this.autoLogout = ko.observable(30);
-
+		this.displayName = ko.observable('');
 		this.computers();
 		this.subscribers();
 	}
@@ -72,6 +72,7 @@
 	{
 		this.layout(Utils.pInt(Settings.settingsGet('Layout')));
 		this.editorDefaultType(Settings.settingsGet('EditorDefaultType'));
+		this.displayName(Settings.settingsGet('DisplayName'));
 
 		this.autoLogout(Utils.pInt(Settings.settingsGet('AutoLogout')));
 		this.messagesPerPage(Settings.settingsGet('MPP'));

--- a/dev/View/User/AbstractSystemDropDown.js
+++ b/dev/View/User/AbstractSystemDropDown.js
@@ -16,6 +16,7 @@
 		AppStore = require('Stores/User/App'),
 		AccountStore = require('Stores/User/Account'),
 		MessageStore = require('Stores/User/Message'),
+		SettingsStore = require('Stores/User/Settings'),
 
 		Settings = require('Storage/Settings'),
 
@@ -82,7 +83,7 @@
 
 	AbstractSystemDropDownUserView.prototype.emailTitle = function ()
 	{
-		return AccountStore.email();
+		return SettingsStore.displayName();
 	};
 
 	AbstractSystemDropDownUserView.prototype.settingsClick = function ()

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -1747,6 +1747,7 @@ class Actions
 
 			$aResult['UseThreads'] = (bool) $oSettingsLocal->GetConf('UseThreads', $aResult['UseThreads']);
 			$aResult['ReplySameFolder'] = (bool) $oSettingsLocal->GetConf('ReplySameFolder', $aResult['ReplySameFolder']);
+			$aResult['DisplayName'] = $oSettings->GetConf('DisplayName', $aResult['Email']);
 
 			if (!$this->GetCapa(false, \RainLoop\Enumerations\Capa::AUTOLOGOUT, $oAccount))
 			{
@@ -4832,6 +4833,7 @@ class Actions
 		});
 
 		$this->setSettingsFromParams($oSettings, 'EditorDefaultType', 'string');
+		$this->setSettingsFromParams($oSettings, 'DisplayName', 'string');
 		$this->setSettingsFromParams($oSettings, 'ShowImages', 'bool');
 		$this->setSettingsFromParams($oSettings, 'ContactsAutosave', 'bool');
 		$this->setSettingsFromParams($oSettings, 'DesktopNotifications', 'bool');

--- a/rainloop/v/0.0.0/app/templates/Views/User/SettingsGeneral.html
+++ b/rainloop/v/0.0.0/app/templates/Views/User/SettingsGeneral.html
@@ -71,6 +71,21 @@
 		</div>
 		<div class="control-group">
 			<label class="control-label">
+				<span class="i18n" data-i18n="CONTACTS/LABEL_DISPLAY_NAME"></span>
+			</label>
+			<div class="controls">
+				<div data-bind="component: {
+					name: 'Input',
+					params: {
+						value: displayName,
+						trigger: displayNameTrigger,
+						size: 30
+					}
+				}"></div>
+			</div>
+		</div>
+		<div class="control-group">
+			<label class="control-label">
 			   <span class="i18n" data-i18n="SETTINGS_GENERAL/LABEL_MESSAGE_PER_PAGE"></span>
 			</label>
 			<div class="controls">


### PR DESCRIPTION
Before this, it would only show the email address.  Now user can change what it says.

It currently has an issue where the change doesn't show up until the page is reloaded which I suspect is due to accessing it via Stores/User/Account vs. Stores/User/Settings.  But I tried only using one of them, but it would unceremoniously log me out after logging in.  Clearly I'm missing something...