### PR TITLE
Break username and domain from login on last @ instead of first @

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/MailSo/Base/Utils.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Base/Utils.php
@@ -872,7 +872,7 @@ END;
 		$sResult = '';
 		if (0 < \strlen($sEmail))
 		{
-			$iPos = \strpos($sEmail, '@');
+			$iPos = \strrpos($sEmail, '@');
 			$sResult = (false === $iPos) ? $sEmail : \substr($sEmail, 0, $iPos);
 		}
 
@@ -889,7 +889,7 @@ END;
 		$sResult = '';
 		if (0 < \strlen($sEmail))
 		{
-			$iPos = \strpos($sEmail, '@');
+			$iPos = \strrpos($sEmail, '@');
 			if (false !== $iPos && 0 < $iPos)
 			{
 				$sResult = \substr($sEmail, $iPos + 1);


### PR DESCRIPTION
When pulling apart the username and domain for domain checking and such, break on the last @ symbol instead of the first one.  Dovecot master usernames can look like `username@domain.com*adminuser@domain.com`.