### PR TITLE
Added address parameter to vacation filter

### DIFF
--- a/dev/Model/Filter.js
+++ b/dev/Model/Filter.js
@@ -10,8 +10,9 @@
 		Enums = require('Common/Enums'),
 		Utils = require('Common/Utils'),
 		Translator = require('Common/Translator'),
-
 		Cache = require('Common/Cache'),
+
+        AccountStore = require('Stores/User/Account'),
 
 		FilterConditionModel = require('Model/FilterCondition'),
 
@@ -42,6 +43,8 @@
 
 		this.actionValueSecond = ko.observable('');
 		this.actionValueThird = ko.observable('');
+		this.actionValueFourth = ko.observable('');
+        this.actionValueFourth.error = ko.observable(false);
 
 		this.actionMarkAsRead = ko.observable(false);
 
@@ -55,6 +58,13 @@
 			this.actionValue.error(false);
 			this.actionValueSecond('');
 			this.actionValueThird('');
+			this.actionValueFourth('');
+            this.actionValueFourth.error(false);
+            if (Enums.FiltersAction.Vacation === this.actionType())
+            {
+                this.actionValueFourth(AccountStore.accountsEmails());
+            }
+
 		}, this);
 
 		var fGetRealFolderName = function (sFolderFullNameRaw) {
@@ -189,6 +199,17 @@
 			return false;
 		}
 
+        if (Enums.FiltersAction.Vacation === this.actionType() &&
+            (
+                "" === this.actionValueFourth() ||
+                -1 === this.actionValueFourth().indexOf('@')
+            )
+        )
+        {
+            this.actionValueFourth.error(true);
+            return false;
+        }
+
 		this.name.error(false);
 		this.actionValue.error(false);
 
@@ -209,6 +230,7 @@
 			'ActionValue': this.actionValue(),
 			'ActionValueSecond': this.actionValueSecond(),
 			'ActionValueThird': this.actionValueThird(),
+			'ActionValueFourth': this.actionValueFourth(),
 			'ActionType': this.actionType(),
 
 			'Stop': this.actionNoStop() ? '0' : '1',
@@ -255,6 +277,7 @@
 			this.actionValue(Utils.pString(oItem['ActionValue']));
 			this.actionValueSecond(Utils.pString(oItem['ActionValueSecond']));
 			this.actionValueThird(Utils.pString(oItem['ActionValueThird']));
+			this.actionValueFourth(Utils.pString(oItem['ActionValueFourth']));
 
 			this.actionNoStop(!oItem['Stop']);
 			this.actionKeep(!!oItem['Keep']);
@@ -288,6 +311,7 @@
 
 		oClone.actionValueSecond(this.actionValueSecond());
 		oClone.actionValueThird(this.actionValueThird());
+		oClone.actionValueFourth(this.actionValueFourth());
 
 		oClone.actionKeep(this.actionKeep());
 		oClone.actionNoStop(this.actionNoStop());

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Providers/Filters/Classes/Filter.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Providers/Filters/Classes/Filter.php
@@ -49,6 +49,11 @@ class Filter
 	 */
 	private $sActionValueThird;
 
+    /**
+     * @var string
+     */
+    private $sActionValueFourth;
+
 	/**
 	 * @var bool
 	 */
@@ -89,6 +94,7 @@ class Filter
 		$this->sActionValue = '';
 		$this->sActionValueSecond = '';
 		$this->sActionValueThird = '';
+		$this->sActionValueFourth = '';
 
 		$this->bMarkAsRead = false;
 		$this->bKeep = true;
@@ -167,6 +173,14 @@ class Filter
 		return $this->sActionValueThird;
 	}
 
+    /**
+     * @return string
+     */
+    public function ActionValueFourth()
+    {
+        return $this->sActionValueFourth;
+    }
+
 	/**
 	 * @return bool
 	 */
@@ -236,6 +250,7 @@ class Filter
 			$this->sActionValue = isset($aFilter['ActionValue']) ? $aFilter['ActionValue'] : '';
 			$this->sActionValueSecond = isset($aFilter['ActionValueSecond']) ? $aFilter['ActionValueSecond'] : '';
 			$this->sActionValueThird = isset($aFilter['ActionValueThird']) ? $aFilter['ActionValueThird'] : '';
+			$this->sActionValueFourth = isset($aFilter['ActionValueFourth']) ? $aFilter['ActionValueFourth'] : '';
 
 			$this->bKeep = isset($aFilter['Keep']) ? '1' === (string) $aFilter['Keep'] : true;
 			$this->bStop = isset($aFilter['Stop']) ? '1' === (string) $aFilter['Stop'] : true;
@@ -276,6 +291,7 @@ class Filter
 			'ActionValue' => $this->ActionValue(),
 			'ActionValueSecond' => $this->ActionValueSecond(),
 			'ActionValueThird' => $this->ActionValueThird(),
+			'ActionValueFourth' => $this->ActionValueFourth(),
 			'Keep' => $this->Keep(),
 			'Stop' => $this->Stop(),
 			'MarkAsRead' => $this->MarkAsRead()

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Providers/Filters/SieveStorage.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Providers/Filters/SieveStorage.php
@@ -350,6 +350,7 @@ class SieveStorage implements \RainLoop\Providers\Filters\FiltersInterface
 				$sValue = \trim($oFilter->ActionValue());
 				$sValueSecond = \trim($oFilter->ActionValueSecond());
 				$sValueThird = \trim($oFilter->ActionValueThird());
+				$sValueFourth = \trim($oFilter->ActionValueFourth());
 				if (0 < \strlen($sValue))
 				{
 					$aCapa['vacation'] = true;
@@ -367,7 +368,14 @@ class SieveStorage implements \RainLoop\Providers\Filters\FiltersInterface
 						$iDays = (int) $sValueThird;
 					}
 
-					$aResult[] = $sTab.'vacation :days '.$iDays.' '.$sSubject.'"'.$this->quote($sValue).'";';
+                    if (0 < \strlen($sValueFourth))
+                    {
+                        $aAddresses = \explode(",", $sValueFourth);
+                        $aAddresses = array_map('trim', $aAddresses);
+                        $sAddresses = ':addresses ["' . \implode('", "', $aAddresses) . '"]';
+                    }
+
+                    $aResult[] = $sTab.'vacation :days '.$iDays.' '.$sAddresses.' '.$sSubject.'"'.$this->quote($sValue).'";';
 
 					if ($oFilter->Stop())
 					{

--- a/rainloop/v/0.0.0/app/templates/Views/User/SettingsFiltersActionVacation.html
+++ b/rainloop/v/0.0.0/app/templates/Views/User/SettingsFiltersActionVacation.html
@@ -9,15 +9,23 @@
 				size: 1
 			}
 		}"></div>
-		<input type="text" class="span5 i18n" data-bind="value: actionValueSecond"
+        <input type="text" class="span5 i18n" data-bind="value: actionValueSecond"
 			data-i18n="[placeholder]POPUPS_FILTER/VACATION_SUBJECT_LABEL" />
 	</div>
 </div>
+
+<div class="control-group" data-bind="css: {'error': actionValueFourth.error}" style="margin-bottom: 0">
+    <div class="controls">
+<input type="text" class="span5 i18n" data-bind="value: actionValueFourth"
+       data-i18n="[placeholder]POPUPS_FILTER/VACATION_RECIPIENTS_LABEL" />
+    </div>
+</div>
+
 <div class="control-group" data-bind="css: {'error': actionValue.error}" style="margin-bottom: 0">
 	<div class="controls">
 		<textarea class="span5 i18n" data-bind="value: actionValue" style="height: 100px;"
 			data-i18n="[placeholder]POPUPS_FILTER/VACATION_MESSAGE_LABEL"></textarea>
-	</div>
+        <div class="controls">
 </div>
 <div class="control-group">
 	<div class="controls">

--- a/rainloop/v/0.0.0/langs/bg.ini
+++ b/rainloop/v/0.0.0/langs/bg.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/cs.ini
+++ b/rainloop/v/0.0.0/langs/cs.ini
@@ -362,6 +362,7 @@ STOP_LABEL = "Neukončovat zpracování pravidel"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Předmět (volitelný)"
 VACATION_MESSAGE_LABEL = "Zpráva"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Odmítnout zprávu"
 ALL_INCOMING_MESSAGES_DESC = "Všechny příchozí zprávy"
 

--- a/rainloop/v/0.0.0/langs/de.ini
+++ b/rainloop/v/0.0.0/langs/de.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Weiterverarbeitung der Regeln nicht verhindern"
 EMAIL_LABEL = "E-Mail"
 VACATION_SUBJECT_LABEL = "Betreff (optional)"
 VACATION_MESSAGE_LABEL = "Nachricht"
+VACATION_RECIPIENTS_LABEL = "Empfänger (kommasepariert)"
 REJECT_MESSAGE_LABEL = "Ablehnnachricht"
 ALL_INCOMING_MESSAGES_DESC = "Alle eingehenden Nachrichten"
 

--- a/rainloop/v/0.0.0/langs/en-gb.ini
+++ b/rainloop/v/0.0.0/langs/en-gb.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/en.ini
+++ b/rainloop/v/0.0.0/langs/en.ini
@@ -369,6 +369,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/es.ini
+++ b/rainloop/v/0.0.0/langs/es.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/fr.ini
+++ b/rainloop/v/0.0.0/langs/fr.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Ne pas arrêter le traîtement des règles"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Sujet (optionnel)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Message rejeté"
 ALL_INCOMING_MESSAGES_DESC = "Tous les messages entrants"
 

--- a/rainloop/v/0.0.0/langs/hu.ini
+++ b/rainloop/v/0.0.0/langs/hu.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/is.ini
+++ b/rainloop/v/0.0.0/langs/is.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/it.ini
+++ b/rainloop/v/0.0.0/langs/it.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Non interrompere l'elaborazione delle regole"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Oggetto (opzionale)"
 VACATION_MESSAGE_LABEL = "Messaggio"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Rifiuta messagio"
 ALL_INCOMING_MESSAGES_DESC = "Tutti i messaggi in ingresso"
 

--- a/rainloop/v/0.0.0/langs/ja-jp.ini
+++ b/rainloop/v/0.0.0/langs/ja-jp.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/ko-kr.ini
+++ b/rainloop/v/0.0.0/langs/ko-kr.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/lt.ini
+++ b/rainloop/v/0.0.0/langs/lt.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Nesustoti vykdyti taisykles"
 EMAIL_LABEL = "E-paštas"
 VACATION_SUBJECT_LABEL = "Tema (nebūtina)"
 VACATION_MESSAGE_LABEL = "Žinutė"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Atmesti žinutę"
 ALL_INCOMING_MESSAGES_DESC = "Visi ateinantys laiškai"
 

--- a/rainloop/v/0.0.0/langs/lv.ini
+++ b/rainloop/v/0.0.0/langs/lv.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/nl.ini
+++ b/rainloop/v/0.0.0/langs/nl.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Stop niet met uitvoeren van volgende filters"
 EMAIL_LABEL = "E-mail"
 VACATION_SUBJECT_LABEL = "Onderwerp (optioneel)"
 VACATION_MESSAGE_LABEL = "Bericht"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Afwijsbericht"
 ALL_INCOMING_MESSAGES_DESC = "Alle inkomende berichten"
 

--- a/rainloop/v/0.0.0/langs/no.ini
+++ b/rainloop/v/0.0.0/langs/no.ini
@@ -362,6 +362,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/pl.ini
+++ b/rainloop/v/0.0.0/langs/pl.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Nie zatrzymuj przetwarzania reguł"
 EMAIL_LABEL = "Adres e-mail"
 VACATION_SUBJECT_LABEL = "Temat (opcjonalnie)"
 VACATION_MESSAGE_LABEL = "Wiadomość"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Powód odrzucenia"
 ALL_INCOMING_MESSAGES_DESC = "Wszystkie przychodzące wiadomości"
 

--- a/rainloop/v/0.0.0/langs/pt-br.ini
+++ b/rainloop/v/0.0.0/langs/pt-br.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Não parar o processamento das regras"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Assunto (opcional)"
 VACATION_MESSAGE_LABEL = "Mensagem"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Rejeitar mensagem"
 ALL_INCOMING_MESSAGES_DESC = "Todas as mensagens recebidas"
 

--- a/rainloop/v/0.0.0/langs/pt-pt.ini
+++ b/rainloop/v/0.0.0/langs/pt-pt.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Não parar de processar as regras"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Assunto (opcional)"
 VACATION_MESSAGE_LABEL = "Mensagem"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Rejeitar mensagem"
 ALL_INCOMING_MESSAGES_DESC = "Todas as mensagens recebidas"
 

--- a/rainloop/v/0.0.0/langs/ro.ini
+++ b/rainloop/v/0.0.0/langs/ro.ini
@@ -362,6 +362,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/ru.ini
+++ b/rainloop/v/0.0.0/langs/ru.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Не преращать обработку правил"
 EMAIL_LABEL = "Почтка"
 VACATION_SUBJECT_LABEL = "Тема (необязательно)"
 VACATION_MESSAGE_LABEL = "Сообщение"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Причина (будет послана отправителю)"
 ALL_INCOMING_MESSAGES_DESC = "Все входящие сообщения"
 

--- a/rainloop/v/0.0.0/langs/sk.ini
+++ b/rainloop/v/0.0.0/langs/sk.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/sv.ini
+++ b/rainloop/v/0.0.0/langs/sv.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/tr.ini
+++ b/rainloop/v/0.0.0/langs/tr.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/ua.ini
+++ b/rainloop/v/0.0.0/langs/ua.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/zh-cn.ini
+++ b/rainloop/v/0.0.0/langs/zh-cn.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 

--- a/rainloop/v/0.0.0/langs/zh-tw.ini
+++ b/rainloop/v/0.0.0/langs/zh-tw.ini
@@ -363,6 +363,7 @@ STOP_LABEL = "Don't stop processing rules"
 EMAIL_LABEL = "Email"
 VACATION_SUBJECT_LABEL = "Subject (optional)"
 VACATION_MESSAGE_LABEL = "Message"
+VACATION_RECIPIENTS_LABEL = "Recipients (comma separated)"
 REJECT_MESSAGE_LABEL = "Reject message"
 ALL_INCOMING_MESSAGES_DESC = "All incoming messages"
 


### PR DESCRIPTION
This patch allows to set the address parameter (https://tools.ietf.org/html/rfc5230, 4.5.  Address Parameter and Limiting Replies to Personal Messages), which is required for our usage.

An required fourth parameter is added to the vacation filter popup and automatically filled with the users email address.

Is there any chance this could be merged ? 