### PR TITLE
Add `ZipArchive::CREATE` flag for PHP 5.6

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -2855,7 +2855,7 @@ class Actions
 						if (!empty($sZipFileName))
 						{
 							$oZip = new \ZipArchive();
-							$oZip->open($sZipFileName, \ZIPARCHIVE::OVERWRITE);
+							$oZip->open($sZipFileName, \ZIPARCHIVE::CREATE | \ZIPARCHIVE::OVERWRITE);
 							$oZip->setArchiveComment('RainLoop/'.APP_VERSION);
 
 							foreach ($aData as $aItem)


### PR DESCRIPTION
Since PHP 5.6, `ZipArchive::open` will return `ZipArchive::ER_NOENT` if the `ZipArchive::CREATE` option is not given and the file doesn't exist, while previously, it was created without error with only `ZipArchive::OVERWRITE`.