### PR TITLE
Use proper terminology

### DIFF
--- a/rainloop/v/0.0.0/langs/fr.ini
+++ b/rainloop/v/0.0.0/langs/fr.ini
@@ -324,7 +324,7 @@ BUTTON_SIGN_AND_ENCRYPT = "Signer et chiffrer"
 TITLE_MESSAGE_OPEN_PGP = "OpenPGP Decrypt"
 LABEL_KEY = "Clé Privée"
 LABEL_PASSWORD = "Mot de passe"
-BUTTON_DECRYPT = "Décrypter"
+BUTTON_DECRYPT = "Déchiffrer"
 
 [POPUPS_TWO_FACTOR_TEST]
 TITLE_TEST_CODE = "Test d'authentification en deux étapes"


### PR DESCRIPTION
In French cryptography terminology, "Décrypter" means breaking encryption to get the plaintext (when not knowing the encryption key), while "Déchiffrer" means recovering a plaintext with the encryption key.

Link: https://fr.wikipedia.org/wiki/Cryptographie
Link: http://www.bortzmeyer.org/cryptage-n-existe-pas.html