### PR TITLE
Modified the postfixadmin-change-password plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /build/dist
 /build/tmp
 /data
+.DS_Store

--- a/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
+++ b/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
@@ -18,6 +18,21 @@ class ChangePasswordPostfixAdminDriver implements \RainLoop\Providers\ChangePass
 	private $sDatabase = 'postfixadmin';
 
 	/**
+	* @var string
+	*/
+	private $sTable = 'mailbox';
+
+	/**
+	* @var string
+	*/
+	private $sUsercol = 'usercol';
+
+	/**
+	* @var string
+	*/
+	private $sPasscol = 'passcol';
+
+	/**
 	 * @var string
 	 */
 	private $sUser = 'postfixadmin';
@@ -72,6 +87,39 @@ class ChangePasswordPostfixAdminDriver implements \RainLoop\Providers\ChangePass
 	public function SetDatabase($sDatabase)
 	{
 		$this->sDatabase = $sDatabase;
+		return $this;
+	}
+
+	/**
+	* @param string $sTable
+	*
+	* @return \ChangePasswordPostfixAdminDriver
+	*/
+	public function SetTable($sTable)
+	{
+		$this->sTable = $sTable;
+		return $this;
+	}
+
+	/**
+	* @param string $sUsercol
+	*
+	* @return \ChangePasswordPostfixAdminDriver
+	*/
+	public function SetUserColumn($sUsercol)
+	{
+		$this->sUsercol = $sUsercol;
+		return $this;
+	}
+
+	/**
+	* @param string $sPasscol
+	*
+	* @return \ChangePasswordPostfixAdminDriver
+	*/
+	public function SetPasswordColumn($sPasscol)
+	{
+		$this->sPasscol = $sPasscol;
 		return $this;
 	}
 
@@ -173,7 +221,7 @@ class ChangePasswordPostfixAdminDriver implements \RainLoop\Providers\ChangePass
 				$sUpdatePassword = $this->cryptPassword($sNewPassword, $oPdo);
 				if (0 < \strlen($sUpdatePassword))
 				{
-					$oStmt = $oPdo->prepare('UPDATE mailbox SET password = ? WHERE username = ?');
+					$oStmt = $oPdo->prepare("UPDATE  $this->sTable SET $this->sPasscol = ? WHERE $this->sUsercol = ?");
 					$bResult = (bool) $oStmt->execute(array($sUpdatePassword, $oAccount->Email()));
 				}
 				else

--- a/plugins/postfixadmin-change-password/index.php
+++ b/plugins/postfixadmin-change-password/index.php
@@ -44,6 +44,9 @@ class PostfixAdminChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
 					->SetHost($this->Config()->Get('plugin', 'host', ''))
 					->SetPort((int) $this->Config()->Get('plugin', 'port', 3306))
 					->SetDatabase($this->Config()->Get('plugin', 'database', ''))
+					->SetTable($this->Config()->Get('plugin', 'table', ''))
+					->SetUserColumn($this->Config()->Get('plugin', 'usercol', ''))
+					->SetPasswordColumn($this->Config()->Get('plugin', 'passcol', ''))
 					->SetUser($this->Config()->Get('plugin', 'user', ''))
 					->SetPassword($this->Config()->Get('plugin', 'password', ''))
 					->SetEncrypt($this->Config()->Get('plugin', 'encrypt', ''))
@@ -68,6 +71,12 @@ class PostfixAdminChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetDefaultValue(3306),
 			\RainLoop\Plugins\Property::NewInstance('database')->SetLabel('MySQL Database')
 				->SetDefaultValue('postfixadmin'),
+			\RainLoop\Plugins\Property::NewInstance('table')->SetLabel('MySQL table')
+				->SetDefaultValue('mailbox'),
+			\RainLoop\Plugins\Property::NewInstance('usercol')->SetLabel('MySQL username column')
+				->SetDefaultValue('username'),
+			\RainLoop\Plugins\Property::NewInstance('passcol')->SetLabel('MySQL password column')
+				->SetDefaultValue('password'),
 			\RainLoop\Plugins\Property::NewInstance('user')->SetLabel('MySQL User')
 				->SetDefaultValue('postfixadmin'),
 			\RainLoop\Plugins\Property::NewInstance('password')->SetLabel('MySQL Password')


### PR DESCRIPTION
**Modified the postfixadmin-change-password plugin to give users these additional options for MySQL:**

* Specify the table name
* Specify the column name for user names
* Specify the column name for the passwords