### PR TITLE
Fixes #693: findIdentityByMessage always selects the default identity

### DIFF
--- a/dev/View/Popup/Compose.js
+++ b/dev/View/Popup/Compose.js
@@ -696,7 +696,10 @@
 				case Enums.ComposeType.ReplyAll:
 				case Enums.ComposeType.Forward:
 				case Enums.ComposeType.ForwardAsAttachment:
-					_.each(_.union(oMessage.to, oMessage.cc, oMessage.bcc, oMessage.deliveredTo), fEachHelper);
+					_.each(_.union(oMessage.to, oMessage.cc, oMessage.bcc), fEachHelper);
+					if (!oResultIdentity) {
+						_.each(oMessage.deliveredTo, fEachHelper);
+					}
 					break;
 				case Enums.ComposeType.Draft:
 					_.each(_.union(oMessage.from, oMessage.replyTo), fEachHelper);


### PR DESCRIPTION
The findIdentityByMessage searches the message "to", "cc", "bcc" and "delivered-to" headers looking for an email address that matches one of the user's identities.  If a match is found, then that identity is used in preference to the default identity.

Unfortunately, findIdentityByMessage gives too great a weight to the default identity.  The existing algorithm works well on a system such as gmail, which uses "+" addressing for alternate email addresses.  For example, imagine you have a gmail account "me@gmail.com" with an alternate identity "me+alternate@gmail.com".  In this instance, if you send an email to "me+alternate@gmail.com", you will receive the following headers:

 To: me+alternate@gmail.com
 Delivered-To: me+alternate@gmail.com

This works great with the existing algorithm; the identity "me+alternate@gmail.com" is selected.  However, imagine that you are instead using a Postfix mail server, with an primary email address "me@mydomain.org" and a virtual email address "alternate-me@mydomain.org" that delivers to "me@mydomain.org".  If you send an email to "alternate-me@mydomain.org", you will get the following headers:

 To: alternate-me@mydomain.org
 X-Original-To: alternate-me@mydomain.org
 Delivered-To: me@mydomain.org

The existing algorithm will consider all matching identities found in any considered header.  (Presently, X-Original-To is not stored in the Message object by Rainloop, so it is not available for consideration.)  When "alternate-me@mydomain.org" is found, the matching identity will be considered a potential result; however, the algorithm gives the highest priority to identities with the smallest index in the identity list.  The primary identity always has an index of zero, and the "Delivered-To" header almost always (always?) contains the primary identity.  This renders this algorithm impotent for Postfix mail servers using virtual email aliases, as it will always select the primary identity, regardless of which virtual address the message was sent to.

This PR removes the 'Delivered-To' header from consideration in the original identity search done by findIdentityByMessage.  If no matches are found in the "to", "cc" or "bcc" headers, then the 'Delivered-To' header is consulted for a match.  (n.b. it seems  pointless to test the bcc header, since it seems to always be empty; however, I did not make any change to this part of the algorithm.)

This results in correct behavior for "+" addressing, including situations where "bcc" is used, and results in correct behavior for Postfix virtual email addresses **except** where "bcc" is used.  To correctly handle Postfix "bcc" emails, the "X-Original-To" email header would also need to be considered; however, that would be a more extensive change, and this PR is adequate for almost every situation.  Postfix users who wanted to fix the "bcc" case could try copying the "X-Original-To" header into the "bcc" header -- but I have not tried this myself.