### PR TITLE
Add support for SHA256-CRYPT and SHA512-CRYPT crypt schemes #939

### DIFF
--- a/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
+++ b/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
@@ -258,6 +258,7 @@ class ChangePasswordPostfixAdminDriver implements \RainLoop\Providers\ChangePass
 	private function cryptPassword($sPassword, $oPdo)
 	{
 		$sResult = '';
+		$sSalt = substr(str_shuffle('./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'), 0, 16);
 		switch ($this->sEncrypt)
 		{
 			default:
@@ -277,6 +278,14 @@ class ChangePasswordPostfixAdminDriver implements \RainLoop\Providers\ChangePass
 
 			case 'system':
 				$sResult = crypt($sPassword);
+				break;
+
+			case 'SHA256-CRYPT':
+				$sResult = '{SHA256-CRYPT}' . crypt($sPassword,'$5$'.$sSalt);
+				break;
+
+			case 'SHA512-CRYPT':
+				$sResult = '{SHA512-CRYPT}' . crypt($sPassword,'$6$'.$sSalt);
 				break;
 
 			case 'mysql_encrypt':

--- a/plugins/postfixadmin-change-password/index.php
+++ b/plugins/postfixadmin-change-password/index.php
@@ -84,7 +84,7 @@ class PostfixAdminChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetDefaultValue(''),
 			\RainLoop\Plugins\Property::NewInstance('encrypt')->SetLabel('Encrypt')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::SELECTION)
-				->SetDefaultValue(array('md5crypt', 'md5', 'system', 'cleartext', 'mysql_encrypt'))
+				->SetDefaultValue(array('md5crypt', 'md5', 'system', 'cleartext', 'mysql_encrypt', 'SHA256-CRYPT', 'SHA512-CRYPT'))
 				->SetDescription('In what way do you want the passwords to be crypted ?'),
 			\RainLoop\Plugins\Property::NewInstance('allowed_emails')->SetLabel('Allowed emails')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::STRING_TEXT)


### PR DESCRIPTION
I try it just now, compatible with Postfixadmin and Dovecot password schemes.
http://wiki.dovecot.org/Authentication/PasswordSchemes


linked to : https://github.com/RainLoop/rainloop-webmail/issues/939