### PR TITLE
Create Debian Package

### DIFF
--- a/makedeb.sh
+++ b/makedeb.sh
@@ -33,7 +33,6 @@ mv data $DIR/var/lib/rainloop;
 
 #Update settings for Debian package
 sed -i "s/\$sCustomDataPath = '';/\$sCustomDataPath = '\/var\/lib\/rainloop';/" $DIR/usr/share/rainloop/rainloop/v/$VERSION/include.php
-sed -i "s/\$sCustomDataPath = \(.*\) : '';/\$sCustomDataPath = \1 : \$sCustomDataPath;/" $DIR/usr/share/rainloop/rainloop/v/$VERSION/include.php
 
 #Set up Debian packaging tools
 cd $DIR;

--- a/makedeb.sh
+++ b/makedeb.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#Build RainLoop Webmail Debian Package
+PACKAGEVERSION="0";
+
+#Build rainloop
+gulp build;
+cd build/dist/releases/webmail;
+cd $(ls -t);	#Most recent build folder
+
+#Working directory
+mkdir rainloop-deb-build;
+cd rainloop-deb-build;
+
+#Prepare zip file
+unzip ../rainloop-community-latest.zip;
+find . -type d -exec chmod 755 {} \;
+find . -type f -exec chmod 644 {} \;
+
+#Set up package directory
+VERSION=$(cat data/VERSION);
+DIR="rainloop_$VERSION-$PACKAGEVERSION";
+mkdir -m 0755 -p $DIR;
+mkdir -m 0755 -p $DIR/usr;
+mkdir -m 0755 -p $DIR/usr/share;
+mkdir -m 0755 -p $DIR/usr/share/rainloop;
+mkdir -m 0755 -p $DIR/var;
+mkdir -m 0755 -p $DIR/var/lib;
+
+#Move files into package directory
+mv rainloop $DIR/usr/share/rainloop/rainloop;
+mv index.php $DIR/usr/share/rainloop/index.php;
+mv data $DIR/var/lib/rainloop;
+
+#Update settings for Debian package
+sed -i "s/\$sCustomDataPath = '';/\$sCustomDataPath = '\/var\/lib\/rainloop';/" $DIR/usr/share/rainloop/rainloop/v/$VERSION/include.php
+sed -i "s/\$sCustomDataPath = \(.*\) : '';/\$sCustomDataPath = \1 : \$sCustomDataPath;/" $DIR/usr/share/rainloop/rainloop/v/$VERSION/include.php
+
+#Set up Debian packaging tools
+cd $DIR;
+mkdir -m 0755 DEBIAN;
+
+#Create Debian packging control file
+cat >> DEBIAN/control <<-EOF
+	Package: rainloop
+	Version: $VERSION
+	Section: web
+	Priority: optional
+	Architecture: all
+	Depends: php5-fpm (>= 5.4), php5-curl, php5-json
+	Maintainer: Rainloop <support@rainloop.net>
+	Installed-Size: 20330
+	Description: Rainloop Webmail
+	 A modern PHP webmail client.
+EOF
+
+#Create Debian packaging post-install script
+cat >> DEBIAN/postinst <<-EOF
+	#!/bin/sh
+	chown -R www-data:www-data /var/lib/rainloop
+EOF
+chmod +x DEBIAN/postinst;
+
+#Build Debian package
+cd ..;
+fakeroot dpkg-deb -b $DIR;
+
+#Clean up
+mv $DIR.deb ..;
+cd ..;
+rm -rf rainloop-deb-build;

--- a/rainloop/v/0.0.0/include.php
+++ b/rainloop/v/0.0.0/include.php
@@ -55,7 +55,7 @@
 				include_once APP_INDEX_ROOT_PATH.'include.php';
 			}
 
-			$sCustomDataPath = function_exists('__get_custom_data_full_path') ? rtrim(trim(__get_custom_data_full_path()), '\\/') : '';
+			$sCustomDataPath = function_exists('__get_custom_data_full_path') ? rtrim(trim(__get_custom_data_full_path()), '\\/') : $sCustomDataPath;
 			define('APP_DATA_FOLDER_PATH', 0 === strlen($sCustomDataPath) ? APP_INDEX_ROOT_PATH.'data/' : $sCustomDataPath.'/');
 			unset($sCustomDataPath);
 


### PR DESCRIPTION
This script will generate a Debian-style package from the latest build of Rainloop. It's a fairly simple package, so it should be compatible with all Debian-based distributions. Rainloop itself is extracted to `/usr/share/rainloop`, and the data files are stored in `/var/lib/rainloop`. Permissions are set automatically. After installing this package, setting up a websever (or symlinking from a web-accessible directory) to `/usr/share/rainloop` is all that's necessary to begin using the software.

NB: This sort of script isn't the [recommended way to create a Debian package](https://www.debian.org/doc/manuals/maint-guide/start.en.html), so more work would be required to include it in the Debian repositories. Aside from the packaging details, the now-superfluous `rainloop/v/$VERSION` directories should be excluded, and config files should be stored under `/etc` (a symlink to the expected config file location under `/var/lib/rainloop` satisfies this) to comply with Debian standards.

Fixes #1290.