### PR TITLE
Fix incorrect handling of multi-line Header

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/MailSo/Base/Utils.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Base/Utils.php
@@ -788,7 +788,7 @@ END;
 			{
 				if (0 < \strlen($sLine))
 				{
-					$sFirst = $sLine{1};
+					$sFirst = \substr($sLine,0,1);
 					if (' ' === $sFirst || "\t" === $sFirst)
 					{
 						if (!$bSkip)


### PR DESCRIPTION
In my setup, initial version of RemoveHeaderFromHeaders does not remove properly multi-line Headers (only the first line is removed). As a consequence, when using php mail() option for outgoing e-mail, strange things happen when the "To" field contains more than 3 recipients.