### PR TITLE
Improve composition on small screens

### DIFF
--- a/dev/Styles/Compose.less
+++ b/dev/Styles/Compose.less
@@ -85,6 +85,7 @@
 		padding: 10px;
 		background-color: #eee;
 		color: #333;
+		overflow:scroll;
 
 		.e-identity {
 
@@ -110,8 +111,8 @@
 		.e-label {
 			text-align: right;
 			width: 1%;
-			min-width: 70px;
-			padding: 6px 10px;
+			min-width: 50px;
+			padding: 6px 10px 6px 0px;
 
 			html.rl-modal {
 				min-width: 50px;


### PR DESCRIPTION
Two changes:
- Caused header overflow to scroll
- Minimized width of labels

Below are before/after screenshots from an iPhone 5 size screen. Notice how scrolling the header of the composition window does not affect the text editor part.

## Before
![before](https://cloud.githubusercontent.com/assets/3850064/23331931/2d1429fe-fb35-11e6-862f-20cabb308540.png)

## After
![after](https://cloud.githubusercontent.com/assets/3850064/23331932/316deb5c-fb35-11e6-9efc-ca5866e72d5e.png)

_...and after scrolling to the right..._

![after-scroll](https://cloud.githubusercontent.com/assets/3850064/23331945/68545138-fb35-11e6-9731-333cdd96c983.png)
