### PR TITLE
Improve button wrapping behavior

### DIFF
--- a/rainloop/v/0.0.0/app/templates/Views/User/PopupsCompose.html
+++ b/rainloop/v/0.0.0/app/templates/Views/User/PopupsCompose.html
@@ -46,49 +46,51 @@
 										</ul>
 									<!-- /ko -->
 								</div>
-								<div class="btn-group dropdown colored-toggle pull-right" style="margin-right: 4px;">
-									<a class="btn single dropdown-toggle buttonMore" data-toggle="dropdown">
-										<i class="icon-list"></i>
-									</a>
-									<ul class="dropdown-menu g-ui-menu" role="menu">
-										<li class="e-item" data-bind="click: function () { requestReadReceipt(!requestReadReceipt()); }">
-											<a class="e-link">
-												<i class="icon-checkbox-unchecked" data-bind="css: {'icon-checkbox-checked': requestReadReceipt(), 'icon-checkbox-unchecked': !requestReadReceipt() }"></i>
-												&nbsp;&nbsp;
-												<span class="i18n" data-i18n="COMPOSE/BUTTON_REQUEST_READ_RECEIPT"></span>
-											</a>
-										</li>
-										<li class="e-item" data-bind="click: function () { requestDsn(!requestDsn()); }">
-											<a class="e-link">
-												<i class="icon-checkbox-unchecked" data-bind="css: {'icon-checkbox-checked': requestDsn(), 'icon-checkbox-unchecked': !requestDsn() }"></i>
-												&nbsp;&nbsp;
-												<span class="i18n" data-i18n="COMPOSE/BUTTON_REQUEST_DSN"></span>
-											</a>
-										</li>
-										<li class="e-item" data-bind="click: function () { markAsImportant(!markAsImportant()); }">
-											<a class="e-link">
-												<i class="icon-checkbox-unchecked" data-bind="css: {'icon-checkbox-checked': markAsImportant(), 'icon-checkbox-unchecked': !markAsImportant() }"></i>
-												&nbsp;&nbsp;
-												<span class="i18n" data-i18n="COMPOSE/BUTTON_MARK_AS_IMPORTANT"></span>
-											</a>
-										</li>
-										<li class="divider" data-bind="visible: capaOpenPGP"></li>
-										<li class="e-item" data-bind="visible: capaOpenPGP, click: openOpenPgpPopup, css: {'disabled': isHtml()}">
-											<a class="e-link">
-												<i class="icon-key"></i>
-												&nbsp;&nbsp;
-												<span class="i18n" data-i18n="COMPOSE/BUTTON_OPEN_PGP"></span>
-											</a>
-										</li>
-									</ul>
-								</div>
-								<div class="btn-group pull-right">&nbsp;</div>
-								<div class="btn-group pull-right">
-									<a class="btn single" data-tooltip-join="top" data-bind="visible: allowContacts, command: contactsCommand, tooltip: 'FOLDER_LIST/BUTTON_CONTACTS'">
-										<i class="icon-address-book"></i>
-									</a>
-								</div>
-								<div class="btn-group pull-right">&nbsp;</div>
+								<span class="pull-right">
+									<div class="btn-group dropdown colored-toggle pull-right" style="margin-right: 4px;">
+										<a class="btn single dropdown-toggle buttonMore" data-toggle="dropdown">
+											<i class="icon-list"></i>
+										</a>
+										<ul class="dropdown-menu g-ui-menu" role="menu">
+											<li class="e-item" data-bind="click: function () { requestReadReceipt(!requestReadReceipt()); }">
+												<a class="e-link">
+													<i class="icon-checkbox-unchecked" data-bind="css: {'icon-checkbox-checked': requestReadReceipt(), 'icon-checkbox-unchecked': !requestReadReceipt() }"></i>
+													&nbsp;&nbsp;
+													<span class="i18n" data-i18n="COMPOSE/BUTTON_REQUEST_READ_RECEIPT"></span>
+												</a>
+											</li>
+											<li class="e-item" data-bind="click: function () { requestDsn(!requestDsn()); }">
+												<a class="e-link">
+													<i class="icon-checkbox-unchecked" data-bind="css: {'icon-checkbox-checked': requestDsn(), 'icon-checkbox-unchecked': !requestDsn() }"></i>
+													&nbsp;&nbsp;
+													<span class="i18n" data-i18n="COMPOSE/BUTTON_REQUEST_DSN"></span>
+												</a>
+											</li>
+											<li class="e-item" data-bind="click: function () { markAsImportant(!markAsImportant()); }">
+												<a class="e-link">
+													<i class="icon-checkbox-unchecked" data-bind="css: {'icon-checkbox-checked': markAsImportant(), 'icon-checkbox-unchecked': !markAsImportant() }"></i>
+													&nbsp;&nbsp;
+													<span class="i18n" data-i18n="COMPOSE/BUTTON_MARK_AS_IMPORTANT"></span>
+												</a>
+											</li>
+											<li class="divider" data-bind="visible: capaOpenPGP"></li>
+											<li class="e-item" data-bind="visible: capaOpenPGP, click: openOpenPgpPopup, css: {'disabled': isHtml()}">
+												<a class="e-link">
+													<i class="icon-key"></i>
+													&nbsp;&nbsp;
+													<span class="i18n" data-i18n="COMPOSE/BUTTON_OPEN_PGP"></span>
+												</a>
+											</li>
+										</ul>
+									</div>
+									<div class="btn-group pull-right">&nbsp;</div>
+									<div class="btn-group pull-right">
+										<a class="btn single" data-tooltip-join="top" data-bind="visible: allowContacts, command: contactsCommand, tooltip: 'FOLDER_LIST/BUTTON_CONTACTS'">
+											<i class="icon-address-book"></i>
+										</a>
+									</div>
+									<div class="btn-group pull-right">&nbsp;</div>
+								</span>
 								<span class="pull-right">
 									<span class="i18n g-ui-link" data-i18n="COMPOSE/TITLE_CC"
 										data-bind="visible: !showCc(), click: function () { showCc(true); }"></span>


### PR DESCRIPTION
By wrapping the two "from" line buttons on the composition popup in a `<span class="pull-right">` tag, they will now break lines together instead of separately. See below:

## Before
![before](https://cloud.githubusercontent.com/assets/3850064/23334496/bbaab77a-fb65-11e6-8ac6-e2c1047001fb.png)

## After
![after](https://cloud.githubusercontent.com/assets/3850064/23334497/bec45f74-fb65-11e6-9039-ee11e2c2e68a.png)