### PR TITLE
Fixing #1284, conflict in headers creation when loading images in body message, "Cannot modify header information - headers already sent"

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -8663,12 +8663,14 @@ NewThemeLink IncludeCss LoadingDescriptionEsc TemplatesLink LangLink IncludeBack
 
 					if ($bDownload || $sLoadedData)
 					{
-						\header('Content-Type: '.$sContentTypeOut);
-						\header('Content-Disposition: '.($bDownload ? 'attachment' : 'inline').'; '.
+						if (!headers_sent()) {
+							\header('Content-Type: '.$sContentTypeOut);
+							\header('Content-Disposition: '.($bDownload ? 'attachment' : 'inline').'; '.
 							\trim(\MailSo\Base\Utils::EncodeHeaderUtf8AttributeValue('filename', $sFileNameOut)), true);
 
-						\header('Accept-Ranges: bytes');
-						\header('Content-Transfer-Encoding: binary');
+							\header('Accept-Ranges: bytes');
+							\header('Content-Transfer-Encoding: binary');
+						}
 
 						if ($bIsRangeRequest && !$sLoadedData)
 						{


### PR DESCRIPTION
In #1284, we noticed a conflict of headers "already sent" when an image is lazy loaded in the body of a message displayed in Rainloop. This little fix seems to fix it without visible regressions.
However, this should be reviewed carefully by people more knowledgeable on that part of the Rainloop code.
Thanks!