### PR TITLE
Fix Gravatar when e-mail address contains uppercase characters

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -8918,7 +8918,7 @@ NewThemeLink IncludeCss LoadingDescriptionEsc TemplatesLink LangLink IncludeBack
 			$iCode = 0;
 			$sContentType = '';
 
-			$sGravatarUrl = 'http://gravatar.com/avatar/'.\md5($sEmail).'.jpg?s=80&d=404';
+			$sGravatarUrl = 'http://gravatar.com/avatar/'.\md5(strtolower($sEmail)).'.jpg?s=80&d=404';
 
 			$this->Logger()->Write('gravatar: '.$sGravatarUrl);
 


### PR DESCRIPTION
When you receive an e-mail from an address with uppercase characters, Rainloop is not able to pull the correct image. This fixes it (tested).
Please see this site for more background information: http://gravatar.com/site/implement/hash/