### PR TITLE
Fix the case for 'Mime-Version'

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/MailSo/Mime/Enumerations/Header.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Mime/Enumerations/Header.php
@@ -60,7 +60,7 @@ class Header
 	const DISPOSITION_NOTIFICATION_TO = 'Disposition-Notification-To';
 	const X_CONFIRM_READING_TO = 'X-Confirm-Reading-To';
 
-	const MIME_VERSION = 'Mime-Version';
+	const MIME_VERSION = 'MIME-Version';
 	const X_MAILER = 'X-Mailer';
 
 	const X_MSMAIL_PRIORITY = 'X-MSMail-Priority';


### PR DESCRIPTION
As per [RFC 2045](https://tools.ietf.org/html/rfc2045#section-3), the correct way is "MIME-Version". At least one
email filter (Rspamd) is known to [penalize](https://github.com/vstakhov/rspamd/blob/5f037021c35e0394bc5bd12ee7b0c9aaa7f37fe3/rules/headers_checks.lua#L539-L546) the wrong case.
