### PR TITLE
Create index for id_contact and prop_type on rainloop_ab_properties

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Providers/AddressBook/PdoAddressBook.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Providers/AddressBook/PdoAddressBook.php
@@ -1787,7 +1787,8 @@ CREATE TABLE IF NOT EXISTS rainloop_ab_properties (
 
 	PRIMARY KEY(id_prop),
 	INDEX id_user_rainloop_ab_properties_index (id_user),
-	INDEX id_user_id_contact_rainloop_ab_properties_index (id_user, id_contact)
+	INDEX id_user_id_contact_rainloop_ab_properties_index (id_user, id_contact),
+	INDEX id_contact_prop_type_rainloop_ab_properties_index (id_contact, prop_type)
 
 )/*!40000 ENGINE=INNODB *//*!40101 CHARACTER SET utf8 COLLATE utf8_general_ci */;
 


### PR DESCRIPTION
RainLoop does a lot of SQL queries like `SELECT id_prop, id_contact, prop_type, prop_value FROM rainloop_ab_properties WHERE prop_type IN (30,15,16,18) AND id_contact IN (173812,757514);` which takes a lot of time if the `rainloop_ab_properties` is big (quite noticeable with  ~6 million rows).

Use this to create index on an existing table:
`CREATE INDEX id_contact_prop_type_rainloop_ab_properties_index ON rainloop_ab_properties(id_contact, prop_type);`