### PR TITLE
Added MailEnable 'Junk E-mail' and 'Deleted Items' folders support.

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -5214,6 +5214,8 @@ NewThemeLink IncludeCss LoadingDescriptionEsc TemplatesLink LangLink IncludeBack
 				'Draft Mails' => \MailSo\Imap\Enumerations\FolderType::DRAFTS,
 				'Drafts Mail' => \MailSo\Imap\Enumerations\FolderType::DRAFTS,
 				'Drafts Mails' => \MailSo\Imap\Enumerations\FolderType::DRAFTS,
+				
+				'Junk E-mail' => \MailSo\Imap\Enumerations\FolderType::JUNK,
 
 				'Spam' => \MailSo\Imap\Enumerations\FolderType::JUNK,
 				'Spams' => \MailSo\Imap\Enumerations\FolderType::JUNK,
@@ -5221,6 +5223,8 @@ NewThemeLink IncludeCss LoadingDescriptionEsc TemplatesLink LangLink IncludeBack
 				'Junk' => \MailSo\Imap\Enumerations\FolderType::JUNK,
 				'Bulk Mail' => \MailSo\Imap\Enumerations\FolderType::JUNK,
 				'Bulk Mails' => \MailSo\Imap\Enumerations\FolderType::JUNK,
+				
+				'Deleted Items' => \MailSo\Imap\Enumerations\FolderType::TRASH,
 
 				'Trash' => \MailSo\Imap\Enumerations\FolderType::TRASH,
 				'Deleted' => \MailSo\Imap\Enumerations\FolderType::TRASH,


### PR DESCRIPTION
Hello!

First of all, I want to congratulate you for the excellent tool that Rainloop is!

We are using version 1.11.3, and we are getting great results. However, we noticed that Rainloop did not support the standard "Spam" and "Trash" folders of the mail server we used (MailEnable 8.56). To solve the problem, simply add the lines in the file "app / libraries / RainLoop / Actions.php".

Thank you!