### PR TITLE
start tls and gecos

### DIFF
--- a/plugins/ldap-change-password/ChangePasswordLdapDriver.php
+++ b/plugins/ldap-change-password/ChangePasswordLdapDriver.php
@@ -118,13 +118,23 @@ class ChangePasswordLdapDriver implements \RainLoop\Providers\ChangePassword\Cha
 				'{login}' => $oAccount->Login(),
 				'{imap:login}' => $oAccount->Login(),
 				'{imap:host}' => $oAccount->DomainIncHost(),
-				'{imap:port}' => $oAccount->DomainIncPort()
+				'{imap:port}' => $oAccount->DomainIncPort(),
+                '{gecos}' => posix_getpwnam($oAccount->Login())
 			));
 
 			$oCon = @\ldap_connect($this->sHostName, $this->iHostPort);
 			if ($oCon)
 			{
-				@\ldap_set_option($oCon, LDAP_OPT_PROTOCOL_VERSION, 3);
+                if (!@\ldap_set_option($oCon, LDAP_OPT_PROTOCOL_VERSION, 3)) {
+                    $this->oLogger->Write("Failed to set LDAP Protocol version to 3, TLS not supported.",
+                        \MailSo\Log\Enumerations\Type::WARNING, 'LDAP');
+                }
+                else {
+                    if (!ldap_start_tls($oCon)) {
+                        $this->oLogger->Write("Ldap_start_tls failed: ".$oCon,
+                            \MailSo\Log\Enumerations\Type::WARNING, 'LDAP');
+                    }
+                }
 
 				if (!@\ldap_bind($oCon, $sUserDn, $sPrevPassword))
 				{

--- a/plugins/ldap-change-password/index.php
+++ b/plugins/ldap-change-password/index.php
@@ -64,7 +64,7 @@ class LdapChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::INT)
 				->SetDefaultValue(389),
 			\RainLoop\Plugins\Property::NewInstance('user_dn_format')->SetLabel('User DN format')
-				->SetDescription('LDAP user dn format. Supported tokens: {email}, {email:user}, {email:domain}, {login}, {domain}, {domain:dc}, {imap:login}, {imap:host}, {imap:port}')
+				->SetDescription('LDAP user dn format. Supported tokens: {email}, {email:user}, {email:domain}, {login}, {domain}, {domain:dc}, {imap:login}, {imap:host}, {imap:port}, {gecos}')
 				->SetDefaultValue('uid={imap:login},ou=Users,{domain:dc}'),
 			\RainLoop\Plugins\Property::NewInstance('password_field')->SetLabel('Password field')
 				->SetDefaultValue('userPassword'),


### PR DESCRIPTION
* added ldap start_tls support
* added gecos token for use in LDAP user DN in case your user accounts are using cn as rdn.