### PR TITLE
Allow anonymous bind to ldap for contact suggestion search.

### DIFF
--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -44,8 +44,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sNameField = \trim($this->Config()->Get('plugin', 'name_field', ''));
 				$sEmailField = \trim($this->Config()->Get('plugin', 'mail_field', ''));
 
-				if (0 < \strlen($sAccessDn) && 0 < \strlen($sAccessPassword) && 0 < \strlen($sUsersDn) &&
-					0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
+				if (0 < \strlen($sUsersDn) && 0 < \strlen($sObjectClass) && 0 < \strlen($sEmailField))
 				{
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 


### PR DESCRIPTION
Currently ldap-contacts-suggestions plugin does not perform a search when `sAccessDn` and `sAccessPassword` are empty. However, it totally makes sense to perform a search with anonymous bind, which requires both `sAccessDn` and `sAccessPassword` to be empty.

Limitation of performing a search with empty `sAccessDn` and `sAccessPassword` is removed.