### PR TITLE
Added support to additional search field (defaults to "uid")

### DIFF
--- a/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
+++ b/plugins/ldap-contacts-suggestions/LdapContactsSuggestions.php
@@ -35,6 +35,11 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	/**
 	 * @var string
 	 */
+	private $sUidField = 'uid';
+
+	/**
+	 * @var string
+	 */
 	private $sNameField = 'givenname';
 
 	/**
@@ -64,7 +69,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	 *
 	 * @return \LdapContactsSuggestions
 	 */
-	public function SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sNameField, $sEmailField)
+	public function SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sUidField, $sNameField, $sEmailField)
 	{
 		$this->sHostName = $sHostName;
 		$this->iHostPort = $iHostPort;
@@ -72,6 +77,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 		$this->sAccessPassword = $sAccessPassword;
 		$this->sUsersDn = $sUsersDn;
 		$this->sObjectClass = $sObjectClass;
+		$this->sUidField = $sUidField;
 		$this->sNameField = $sNameField;
 		$this->sEmailField = $sEmailField;
 
@@ -128,9 +134,9 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 	 *
 	 * @return array
 	 */
-	private function findNameAndEmail($aLdapItem, $aEmailFields, $aNameFields)
+	private function findNameAndEmail($aLdapItem, $aEmailFields, $aNameFields, $aUidFields)
 	{
-		$sEmail = $sName = '';
+		$sEmail = $sName = $sUid = '';
 		if ($aLdapItem)
 		{
 			foreach ($aEmailFields as $sField)
@@ -156,9 +162,21 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 					}
 				}
 			}
+
+			foreach ($aUidFields as $sField)
+			{
+				if (!empty($aLdapItem[$sField][0]))
+				{
+					$sUid = \trim($aLdapItem[$sField][0]);
+					if (!empty($sUid))
+					{
+						break;
+					}
+				}
+			}
 		}
 
-		return array($sEmail, $sName);
+		return array($sEmail, $sName, $sUid);
 	}
 
 	/**
@@ -200,11 +218,13 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 
 			$aEmails = empty($this->sEmailField) ? array() : \explode(',', $this->sEmailField);
 			$aNames = empty($this->sNameField) ? array() : \explode(',', $this->sNameField);
+			$aUIDs = empty($this->sUidField) ? array() : \explode(',', $this->sUidField);
 
 			$aEmails = \array_map('trim', $aEmails);
 			$aNames = \array_map('trim', $aNames);
+			$aUIDs = \array_map('trim', $aUIDs);
 
-			$aFields = \array_merge($aEmails, $aNames);
+			$aFields = \array_merge($aEmails, $aNames, $aUIDs);
 
 			$aItems = array();
 			$sSubFilter = '';
@@ -238,7 +258,7 @@ class LdapContactsSuggestions implements \RainLoop\Providers\Suggestions\ISugges
 						if ($aItem)
 						{
 							$sName = $sEmail = '';
-							list ($sEmail, $sName) = $this->findNameAndEmail($aItem, $aEmails, $aNames);
+							list ($sEmail, $sName) = $this->findNameAndEmail($aItem, $aEmails, $aNames, $aUIDs);
 							if (!empty($sEmail))
 							{
 								$aResult[] = array($sEmail, $sName);

--- a/plugins/ldap-contacts-suggestions/index.php
+++ b/plugins/ldap-contacts-suggestions/index.php
@@ -41,6 +41,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				$sAccessPassword = \trim($this->Config()->Get('plugin', 'access_password', ''));
 				$sUsersDn = \trim($this->Config()->Get('plugin', 'users_dn_format', ''));
 				$sObjectClass = \trim($this->Config()->Get('plugin', 'object_class', ''));
+				$sSearchField = \trim($this->Config()->Get('plugin', 'search_field', ''));
 				$sNameField = \trim($this->Config()->Get('plugin', 'name_field', ''));
 				$sEmailField = \trim($this->Config()->Get('plugin', 'mail_field', ''));
 
@@ -50,7 +51,7 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 					include_once __DIR__.'/LdapContactsSuggestions.php';
 
 					$oProvider = new LdapContactsSuggestions();
-					$oProvider->SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sNameField, $sEmailField);
+					$oProvider->SetConfig($sHostName, $iHostPort, $sAccessDn, $sAccessPassword, $sUsersDn, $sObjectClass, $sSearchField, $sNameField, $sEmailField);
 
 					$mResult[] = $oProvider;
 				}
@@ -80,6 +81,8 @@ class LdapContactsSuggestionsPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetDefaultValue('ou=People,dc=domain,dc=com'),
 			\RainLoop\Plugins\Property::NewInstance('object_class')->SetLabel('objectClass value')
 				->SetDefaultValue('inetOrgPerson'),
+			\RainLoop\Plugins\Property::NewInstance('search_field')->SetLabel('Search field')
+				->SetDefaultValue('uid'),
 			\RainLoop\Plugins\Property::NewInstance('name_field')->SetLabel('Name field')
 				->SetDefaultValue('givenname'),
 			\RainLoop\Plugins\Property::NewInstance('mail_field')->SetLabel('Mail field')


### PR DESCRIPTION
When sending an e-mail, typing in the field **To:** makes the code query only 2 fields in an LDAP directory (related to the recipient's name and e-mail address). This change aims to add to that query also the **uid**, or some other useful unique identifier, while still retrieving only the name and e-mail address. This is useful for people working in environments where they know themselves only by user/login names (which might be completely different from their real names and/or e-mail addresses).