### PR TITLE
Custom SQL password plugin - SQL injection vulnerability fix

### DIFF
--- a/plugins/change-password-custom-sql/index.php
+++ b/plugins/change-password-custom-sql/index.php
@@ -46,7 +46,7 @@ class ChangePasswordCustomSqlPlugin extends \RainLoop\Plugins\AbstractPlugin
 			\RainLoop\Plugins\Property::NewInstance('mTable')->SetLabel('MySQL Table'),
 			\RainLoop\Plugins\Property::NewInstance('mSql')->SetLabel('SQL statement')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::STRING_TEXT)
-				->SetDescription('SQL statement (allowed wildcards :table, :email, :oldpass, :newpass, :domain, :username). When using MD5 OR SHA1 at tables, write it directly here as SQL functions. Fro non-SQL encryptions use another plugin or wait for new version.')
+				->SetDescription('SQL statement (allowed wildcards :table, :email, :oldpass, :newpass, :domain, :username). Use SQL functions for encryption.')
 				->SetDefaultValue('UPDATE :table SET password = md5(:newpass) WHERE domain = :domain AND username = :username and oldpass = md5(:oldpass)')
 		);
 	}


### PR DESCRIPTION
This is a fix for this issue:
https://github.com/RainLoop/rainloop-webmail/issues/1790

It fixes the SQL injection vulnerability that I found in this plugin.

I rewrote the database code to make use of PDO prepared statement and bound variables instead of `str_replace()`.
I also improved the description in the plugin config.

I tried to respect backwards compatibility with the current version of the plugin, so that current users of the plugin won't need to re-write their custom queries. 

However it could conceivable fail for a few edge cases. For example, PDO prepared statements can't have dynamic column names such as ``SELECT :domain ...``. But who would want this?