### PR TITLE
[WIP] Fix non quoted LIST command, failing on brackets [label]/

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
@@ -2012,6 +2012,8 @@ class ImapClient extends \MailSo\Net\NetClient
 		$bCountOneInited = false;
 		$bCountTwoInited = false;
 
+		$bIsLISTCmd = false;
+
 		$sAtomBuilder = $bTreatAsAtom ? '' : null;
 		$aList = array();
 		if (null !== $oImapResponse)
@@ -2163,6 +2165,11 @@ class ImapClient extends \MailSo\Net\NetClient
 				$sChar = $this->sResponseBuffer[$iPos];
 			}
 
+			if (preg_match('/^\* LIST/', $this->sResponseBuffer))
+			{
+				$bIsLISTCmd = true;
+			}
+
 			switch (true)
 			{
 				case ']' === $sChar:
@@ -2182,7 +2189,7 @@ class ImapClient extends \MailSo\Net\NetClient
 					}
 					$iPos++;
 					break;
-				case '[' === $sChar:
+				case '[' === $sChar && false === $bIsLISTCmd:
 					$bIsClosingBracketSquare = true;
 				case '(' === $sChar:
 					if ('(' === $sChar)


### PR DESCRIPTION
CMD: `* LIST (\HasNoChildren) "/" [label]/Trash` failed because the parser sees the [ as opening for arguments or comments.
Google for example returns it quoted: `* LIST (\HasNoChildren) "/" "[Gmail]/Trash"` then this is no issue.

In the LIST context this failed with a MailSo-Base-Exceptions-InvalidArgumentException, the ResponseList[4] was parsed as a array instead of a string.
This problem exists with Dovecot 2.2

This exception is nicely handled so you won't notice. But it the folders menu it won't show the subfolders because it exits the loop with a exception.

My proposal is quite simple, just check it the current buffered line has LIST at the beginning and checking if current sChar === '[' and is not a LIST command.

Original error:
```
[23:31:07.321][99437e3c] IMAP[WARNING]: MailSo\Base\Exceptions\InvalidArgumentException: MailSo-Base-Exceptions-InvalidArgumentException (Folder.php ~ 77) in /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/MailSo/Imap/Folder.php:77
Stack trace:
#0 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/MailSo/Imap/Folder.php(117): MailSo\Imap\Folder->__construct(Array, '/', Array)
#1 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/MailSo/Imap/ImapClient.php(670): MailSo\Imap\Folder::NewInstance(Array, '/', Array)
#2 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/MailSo/Imap/ImapClient.php(800): MailSo\Imap\ImapClient->getFoldersFromResult(Array, 'LIST', false)
#3 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/MailSo/Imap/ImapClient.php(814): MailSo\Imap\ImapClient->specificFolderList(false, '', '*')
#4 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/MailSo/Mail/MailClient.php(2349): MailSo\Imap\ImapClient->FolderList('', '*')
#5 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/RainLoop/Actions.php(5347): MailSo\Mail\MailClient->Folders('', '*', true, 200)
#6 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/RainLoop/ServiceActions.php(172): RainLoop\Actions->DoFolders()
#7 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/RainLoop/Service.php(146): RainLoop\ServiceActions->ServiceAjax('')
#8 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/RainLoop/Service.php(56): RainLoop\Service->localHandle()
#9 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/libraries/RainLoop/Service.php(79): RainLoop\Service->__construct()
#10 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/app/handle.php(94): RainLoop\Service::Handle()
#11 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/rainloop/v/1.12.1/include.php(228): include('/home/dutchmast...')
#12 /home/dutchmasterserver/domains/mail.dutchmasterserver.nl/public_html/index.php(13): include('/home/dutchmast...')
#13 {main}
```
Output unmodified code:
```
[bc1a974b] IMAP[DATA]: < * LIST (\HasNoChildren) "/" [label]/Trash\r\n
[bc1a974b] INFO[WARNING]: Array
(
    [0] => *
    [1] => LIST
    [2] => Array
        (
            [0] => \HasNoChildren
        )

    [3] => /
    [4] => Array << Failes here.
        (
            [0] => label
        )

    [5] => /Trash
)
```
