### PR TITLE
Use `random_bytes` if available in postfix plugin

### DIFF
--- a/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
+++ b/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
@@ -286,7 +286,11 @@ class ChangePasswordPostfixAdminDriver implements \RainLoop\Providers\ChangePass
 	private function cryptPassword($sPassword, $oPdo)
 	{
 		$sResult = '';
-		$sSalt = substr(str_shuffle('./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'), 0, 16);
+		if (function_exists('random_bytes')) {
+			$sSalt = substr(base64_encode(random_bytes(32)), 0, 16);
+		} else {
+			$sSalt = substr(str_shuffle('./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'), 0, 16);	
+		}
 		switch (strtolower($this->sEncrypt))
 		{
 			default:


### PR DESCRIPTION
The [PHP `str_shuffle()`](http://php.net/manual/en/function.str-shuffle.php) documentation states:

```
This function does not generate cryptographically secure values, and should not be used for cryptographic purposes.
```

This change makes use of [`random_bytes()`](http://php.net/manual/en/function.random-bytes.php) if it's available and falls back to the old (probably ok) `str_shuffle()` implementation.