### PR TITLE
Fix regression

### DIFF
--- a/plugins/contact-group-excel-paste/js/excel_contact_group.js
+++ b/plugins/contact-group-excel-paste/js/excel_contact_group.js
@@ -3,7 +3,7 @@
     function replaceGroup() {
       $('li[data-inputosaurus][title*=","]').each(function (index, elem) {
         var $elem = $(elem)
-        var title = $(elem).attr('title')
+        var title = $elem.attr('title')
         var cut = title.indexOf('<')
         title = title.substr(cut + 1, title.length - cut - 2)
         $elem.parents('ul').find('.ui-autocomplete-input').val(title)


### PR DESCRIPTION
Fixes a regression of plugin contact-group-excel-paste since an update of rainloop that modified CSS classes and JavaScript of autocomplete fields