### PR TITLE
Mispelling in fi_FI translation

### DIFF
--- a/rainloop/v/0.0.0/app/localization/webmail/fi_FI.yml
+++ b/rainloop/v/0.0.0/app/localization/webmail/fi_FI.yml
@@ -85,7 +85,7 @@ fi_FI:
     MENU_SELECT_SEEN: "Luetut"
     MENU_SELECT_FLAGGED: "Merkityt"
     MENU_SELECT_UNFLAGGED: "Merkkaamattomat"
-    EMPTY_LIST: "Tyhjennä lista"
+    EMPTY_LIST: "Tyhjä lista"
     EMPTY_SEARCH_LIST: "Yhtään viestiä ei löytynyt ehdoillasi."
     SEARCH_RESULT_FOR: "Hakutulokset haulle \"%SEARCH%\""
     BACK_TO_MESSAGE_LIST: "Takaisin viestilistaan"


### PR DESCRIPTION
"Empty list" description in empty folders is translated to a verb (empty, tyhjennä) instead of a adjective (empty, tyhjä).
https://fi.glosbe.com/fi/en/tyhjent%C3%A4%C3%A4 (empty, verb)
https://fi.glosbe.com/fi/en/tyhj%C3%A4 (empty, adjective)
![Sieppaa](https://user-images.githubusercontent.com/13228415/64334918-58bf4780-cfe2-11e9-89b5-b2a1acd4c13e.PNG)
