### PR TITLE
Use DATE instead of ARRIVAL for sorting messages (Fixes #1817)

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/MailSo/Mail/MailClient.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Mail/MailClient.php
@@ -1865,7 +1865,7 @@ class MailClient
 		if (!\is_array($aResultUids))
 		{
 			$aResultUids = $bUseSortIfSupported ?
-				$this->oImapClient->MessageSimpleSort(array('REVERSE ARRIVAL'), $sSearchCriterias, true) :
+				$this->oImapClient->MessageSimpleSort(array('REVERSE DATE'), $sSearchCriterias, true) :
 				$this->oImapClient->MessageSimpleSearch($sSearchCriterias, true, \MailSo\Base\Utils::IsAscii($sSearchCriterias) ? '' : 'UTF-8')
 			;
 


### PR DESCRIPTION
This PR changes the sorting of IMAP messages to use the message date (DATE) instead of the arrival date (ARRIVAL) in order to sort the messages in the mailbox pane view correctly.

This fixes issue #1817.
