### PR TITLE
Switch admin password hashing to secure algorithms when available

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Config/Application.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Config/Application.php
@@ -99,7 +99,8 @@ class Application extends \RainLoop\Config\AbstractConfig
 	 */
 	public function SetPassword($sPassword)
 	{
-		if (function_exists('password_hash')) {
+		if (function_exists('password_hash'))
+		{
 			return $this->Set('security', 'admin_password', password_hash($sPassword, PASSWORD_DEFAULT));
 		}
 		return $this->Set('security', 'admin_password', \md5(APP_SALT.$sPassword.APP_SALT));
@@ -115,14 +116,18 @@ class Application extends \RainLoop\Config\AbstractConfig
 		$sPassword = (string) $sPassword;
 		$sConfigPassword = (string) $this->Get('security', 'admin_password', '');
 
-		if (0 < strlen($sConfigPassword)) {
-			if (($sPassword === $sConfigPassword) && ('12345' === $sConfigPassword)) {
+		if (0 < strlen($sConfigPassword))
+		{
+			if (($sPassword === $sConfigPassword) && ('12345' === $sConfigPassword))  // password has not been set
+			{
 				return true;
 			}
-			if (32 == strlen($sConfigPassword)) {	// legacy md5 hash
+			if (32 == strlen($sConfigPassword))  // legacy md5 hash
+			{
 				return (\md5(APP_SALT.$sPassword.APP_SALT) === $sConfigPassword);
 			}
-			if (function_exists('password_verify')) {
+			if (function_exists('password_verify'))  // secure hash
+			{
 				return password_verify($sPassword, $sConfigPassword);
 			}
 		}

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Config/Application.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Config/Application.php
@@ -99,6 +99,9 @@ class Application extends \RainLoop\Config\AbstractConfig
 	 */
 	public function SetPassword($sPassword)
 	{
+		if (function_exists('password_hash')) {
+			return $this->Set('security', 'admin_password', password_hash($sPassword, PASSWORD_DEFAULT));
+		}
 		return $this->Set('security', 'admin_password', \md5(APP_SALT.$sPassword.APP_SALT));
 	}
 
@@ -112,8 +115,18 @@ class Application extends \RainLoop\Config\AbstractConfig
 		$sPassword = (string) $sPassword;
 		$sConfigPassword = (string) $this->Get('security', 'admin_password', '');
 
-		return 0 < \strlen($sPassword) &&
-			(($sPassword === $sConfigPassword && '12345' === $sConfigPassword) || \md5(APP_SALT.$sPassword.APP_SALT) === $sConfigPassword);
+		if (0 < strlen($sConfigPassword)) {
+			if (($sPassword === $sConfigPassword) && ('12345' === $sConfigPassword)) {
+				return true;
+			}
+			if (32 == strlen($sConfigPassword)) {	// legacy md5 hash
+				return (\md5(APP_SALT.$sPassword.APP_SALT) === $sConfigPassword);
+			}
+			if (function_exists('password_verify')) {
+				return password_verify($sPassword, $sConfigPassword);
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
This uses the built-in `password_hash` and `password_verify` when available to replace the insecure md5 hash of the admin password. Falls back to the current algorithm. Also continues to recognize and support existing md5 hashes, changing the admin password will re-hash with the new algorithm.

Note that `password_hash` is using bcrypt by default in the current version of PHP, the default algorithm may change over time. `password_verify` will recognize different standard hash algorithms and verify them all as needed allowing forward compatibility.

Fixes #1816 and #1635 

(will submit another PR to address the weak salt generation) 
