### PR TITLE
Use cryptographically secure random number generator for APP_SALT whe…

### DIFF
--- a/rainloop/v/0.0.0/include.php
+++ b/rainloop/v/0.0.0/include.php
@@ -126,13 +126,22 @@
 
 			if (false === $sSalt)
 			{
-				// random salt
-				$sSalt = '<'.'?php //'
-					.md5(microtime(true).rand(1000, 5000))
-					.md5(microtime(true).rand(5000, 9999))
-					.md5(microtime(true).rand(1000, 5000));
+				if (function_exists('random_bytes'))
+				{	// secure random salt
+					$sSalt = bin2hex(random_bytes(48));
+				}
+				elseif (function_exists('openssl_random_pseudo_bytes'))
+				{	// not-quite as secure random salt
+					$sSalt = bin2hex(openssl_random_pseudo_bytes(48));
+				}
+				else
+				{	// pseudo-random salt
+					$sSalt = md5(microtime(true).rand(1000, 5000))
+						.md5(microtime(true).rand(5000, 9999))
+						.md5(microtime(true).rand(1000, 5000));
+				}
 
-				@file_put_contents(APP_DATA_FOLDER_PATH.'SALT.php', $sSalt);
+				@file_put_contents(APP_DATA_FOLDER_PATH.'SALT.php', '<'.'?php //'.$sSalt);
 			}
 
 			define('APP_SALT', md5($sSalt.APP_PRIVATE_DATA_NAME.$sSalt));

--- a/rainloop/v/0.0.0/include.php
+++ b/rainloop/v/0.0.0/include.php
@@ -124,17 +124,23 @@
 				unset($sCheckName, $sCheckFilePath, $sCheckFolder, $sTest);
 			}
 
-			if (false === $sSalt)
-			{
+			if (false === $sSalt) {
 				if (function_exists('random_bytes'))
 				{	// secure random salt
-					$sSalt = bin2hex(random_bytes(48));
+					try
+					{
+						$sSalt = bin2hex(random_bytes(48));
+					}
+					catch (\Exception $oException)
+					{
+						$sSalt = false;
+					}
 				}
-				elseif (function_exists('openssl_random_pseudo_bytes'))
+				if ((false === $sSalt) && (function_exists('openssl_random_pseudo_bytes')))
 				{	// not-quite as secure random salt
 					$sSalt = bin2hex(openssl_random_pseudo_bytes(48));
 				}
-				else
+				if (false === $sSalt)
 				{	// pseudo-random salt
 					$sSalt = md5(microtime(true).rand(1000, 5000))
 						.md5(microtime(true).rand(5000, 9999))


### PR DESCRIPTION
This uses the built-in `random_bytes` if available, falling back to `openssl_random_pseudo_bytes`, and finally falling back to the existing algorithm to generate the APP_SALT. When availalable, either of the two functions will generate a salt that is significantly more secure than the existing time based algorithm.

Fixes part of #1635 
