### PR TITLE
Load image data for all images

### DIFF
--- a/dev/Model/Message.js
+++ b/dev/Model/Message.js
@@ -743,7 +743,7 @@ class MessageModel extends AbstractModel {
 
 	showLazyExternalImagesInBody() {
 		if (this.body) {
-			$('.lazy.lazy-inited[data-original]', this.body).each(function() {
+			$('.lazy[data-original]', this.body).each(function() {
 				$(this)
 					.attr('src', $(this).attr('data-original')) // eslint-disable-line no-invalid-this
 					.removeAttr('data-original')


### PR DESCRIPTION
People are sending me emails with a lot of images. Right now only images that are lazy loaded before (in the normal message view) are shown in print view or view in separate window. With this patch all images are loaded.