### PR TITLE
plugins/postfixadmin-change-password: Add "ARGON2I"

### DIFF
--- a/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
+++ b/plugins/postfixadmin-change-password/ChangePasswordPostfixAdminDriver.php
@@ -319,6 +319,10 @@ class ChangePasswordPostfixAdminDriver implements \RainLoop\Providers\ChangePass
 			case 'sha512-crypt':
 				$sResult = '{SHA512-CRYPT}' . crypt($sPassword,'$6$'.$sSalt);
 				break;
+				
+			case 'argon2i':
+				$sResult = '{ARGON2I}' . password_hash($sPassword, PASSWORD_ARGON2I);
+				break;
 
 			case 'mysql_encrypt':
 			  if($this->sEngine == 'MySQL'){

--- a/plugins/postfixadmin-change-password/index.php
+++ b/plugins/postfixadmin-change-password/index.php
@@ -89,7 +89,7 @@ class PostfixadminChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
 				->SetDefaultValue(''),
 			\RainLoop\Plugins\Property::NewInstance('encrypt')->SetLabel('Encrypt')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::SELECTION)
-				->SetDefaultValue(array('md5crypt', 'md5', 'system', 'cleartext', 'mysql_encrypt', 'SHA256-CRYPT', 'SHA512-CRYPT'))
+				->SetDefaultValue(array('md5crypt', 'md5', 'system', 'cleartext', 'argon2i', 'mysql_encrypt', 'SHA256-CRYPT', 'SHA512-CRYPT'))
 				->SetDescription('In what way do you want the passwords to be crypted ?'),
 			\RainLoop\Plugins\Property::NewInstance('allowed_emails')->SetLabel('Allowed emails')
 				->SetType(\RainLoop\Enumerations\PluginPropertyType::STRING_TEXT)


### PR DESCRIPTION
My mail server was set up with `dovecot:ARGON2I` password encryption option.  This allows people who set up argon2i as the encryption method to continue using it when users change their password with the plugin.