### PR TITLE
throw 403 on access denied

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Service.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Service.php
@@ -130,6 +130,7 @@ class Service
 
 		if ($bAdmin && !$this->oActions->Config()->Get('security', 'allow_admin_panel', true))
 		{
+			$this->oHttp->StatusHeader(403);
 			echo $this->oServiceActions->ErrorTemplates('Access Denied.',
 				'Access to the RainLoop Webmail Admin Panel is not allowed!', true);
 


### PR DESCRIPTION
Currently when the admin page is disabled you'll get an 200 OK with a message, that access is denied. This PR instead throws a 403 Forbidden to be more in line with the content of the page.

fixes #1838