### PR TITLE
Replace WeakPassword 12345 with a more secure version

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -1587,6 +1587,16 @@ NewThemeLink IncludeCss LoadingDescriptionEsc LangLink IncludeBackground Plugins
 
 		$oSettings = null;
 
+		$passfile = APP_PRIVATE_DATA.'admin_password.txt';
+		$sPassword = $oConfig->Get('security', 'admin_password', '');
+		if (!$sPassword) {
+			$sPassword = \substr(\base64_encode(\random_bytes(16)), 0, 12);
+			\file_put_contents($passfile, $sPassword);
+			\chmod($passfile, 0600);
+			$oConfig->SetPassword($sPassword);
+			$oConfig->Save();
+		}
+
 		if (!$bAdmin)
 		{
 			$oAccount = $this->getAccountFromToken(false);
@@ -1814,7 +1824,7 @@ NewThemeLink IncludeCss LoadingDescriptionEsc LangLink IncludeBackground Plugins
 				$aResult['SubscriptionEnabled'] = (bool) \MailSo\Base\Utils::ValidateDomain($aResult['AdminDomain'], true);
 //					|| \MailSo\Base\Utils::ValidateIP($aResult['AdminDomain']);
 
-				$aResult['WeakPassword'] = (bool) $oConfig->ValidatePassword('12345');
+				$aResult['WeakPassword'] = \is_file($passfile);;
 				$aResult['CoreAccess'] = (bool) $this->rainLoopCoreAccess();
 
 				$aResult['PhpUploadSizes'] = array(
@@ -4087,6 +4097,8 @@ NewThemeLink IncludeCss LoadingDescriptionEsc LangLink IncludeBackground Plugins
 			$this->Logger()->AddSecret($sNewPassword);
 		}
 
+		$passfile = APP_PRIVATE_DATA.'admin_password.txt';
+
 		if ($oConfig->ValidatePassword($sPassword))
 		{
 			if (0 < \strlen($sLogin))
@@ -4099,11 +4111,10 @@ NewThemeLink IncludeCss LoadingDescriptionEsc LangLink IncludeBackground Plugins
 				$oConfig->SetPassword($sNewPassword);
 			}
 
-			$bResult = true;
+			$bResult = $oConfig->Save();
 		}
 
-		return $this->DefaultResponse(__FUNCTION__, $bResult ?
-			($oConfig->Save() ? array('Weak' => $oConfig->ValidatePassword('12345')) : false) : false);
+		return $this->DefaultResponse(__FUNCTION__, $bResult ? array('Weak' => \is_file($passfile)) : false);
 	}
 
 	/**
@@ -5246,7 +5257,7 @@ NewThemeLink IncludeCss LoadingDescriptionEsc LangLink IncludeBackground Plugins
 				'Draft Mails' => \MailSo\Imap\Enumerations\FolderType::DRAFTS,
 				'Drafts Mail' => \MailSo\Imap\Enumerations\FolderType::DRAFTS,
 				'Drafts Mails' => \MailSo\Imap\Enumerations\FolderType::DRAFTS,
-				
+
 				'Junk E-mail' => \MailSo\Imap\Enumerations\FolderType::JUNK,
 
 				'Spam' => \MailSo\Imap\Enumerations\FolderType::JUNK,
@@ -5255,7 +5266,7 @@ NewThemeLink IncludeCss LoadingDescriptionEsc LangLink IncludeBackground Plugins
 				'Junk' => \MailSo\Imap\Enumerations\FolderType::JUNK,
 				'Bulk Mail' => \MailSo\Imap\Enumerations\FolderType::JUNK,
 				'Bulk Mails' => \MailSo\Imap\Enumerations\FolderType::JUNK,
-				
+
 				'Deleted Items' => \MailSo\Imap\Enumerations\FolderType::TRASH,
 
 				'Trash' => \MailSo\Imap\Enumerations\FolderType::TRASH,

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -4109,6 +4109,9 @@ NewThemeLink IncludeCss LoadingDescriptionEsc LangLink IncludeBackground Plugins
 			if (0 < \strlen(\trim($sNewPassword)))
 			{
 				$oConfig->SetPassword($sNewPassword);
+				if (\is_file($passfile) && \trim(\file_get_contents($passfile)) !== $sNewPassword) {
+					\unlink($passfile);
+				}
 			}
 
 			$bResult = $oConfig->Save();

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Config/Application.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Config/Application.php
@@ -216,11 +216,11 @@ class Application extends \RainLoop\Config\AbstractConfig
 				'custom_server_signature'	=> array('RainLoop'),
 				'x_frame_options_header'	=> array(''),
 				'x_xss_protection_header'	=> array('1; mode=block'),
-				
+
 				'openpgp'					=> array(false),
 
 				'admin_login'				=> array('admin', 'Login and password for web admin panel'),
-				'admin_password'			=> array('12345'),
+				'admin_password'			=> array(''),
 				'allow_admin_panel'			=> array(true, 'Access settings'),
 				'allow_two_factor_auth'		=> array(false),
 				'force_two_factor_auth'		=> array(false),


### PR DESCRIPTION
This modification removes the very weak '12345' with a random string.
The string must be read from the private `/data/_data_/_default_/admin_password.txt` file
When admin changes this "weak" password the file is removed.

It's a much better approach then a default password to prevent massive abuse.