### PR TITLE
Fix RestChangePasswordDriver

### DIFF
--- a/plugins/rest-change-password/RestChangePasswordDriver.php
+++ b/plugins/rest-change-password/RestChangePasswordDriver.php
@@ -38,8 +38,8 @@ class RestChangePasswordDriver implements \RainLoop\Providers\ChangePassword\Cha
     private $oLogger = null;
 
     /**
-     * @param string $sHost
-     * @param int $iPort
+     * @param string $sUrl
+     * @param string $sKey
      *
      * @return \RestChangePasswordDriver
      */
@@ -50,8 +50,6 @@ class RestChangePasswordDriver implements \RainLoop\Providers\ChangePassword\Cha
 
         return $this;
     }
-
-    $oProvider->SetFieldNames($sFieldEmail, $sFieldOldpassword, $sFieldNewpassword);
 
     /**
      * @param string $sFieldEmail
@@ -120,12 +118,16 @@ class RestChangePasswordDriver implements \RainLoop\Providers\ChangePassword\Cha
         }
 
         $bResult = false;
-        if (!empty($this->sHost) && 0 < $this->iPort && $oAccount)
+        if (!empty($this->sUrl) && $oAccount)
         {
             $sEmail = \trim(\strtolower($oAccount->Email()));
 
+            $sUrl = $this->sUrl;
             # Adding  the REST Api key to the url, try to use always https
-            $sUrl = str_replace('://', '://'+$this->sKey+"@", $this->sUrl);
+            if (!empty($this->sKey))
+            {
+                $sUrl = str_replace('://', '://'+$this->sKey+"@", $this->sUrl);
+            }
 
             $iCode = 0;
             $oHttp = \MailSo\Base\Http::SingletonInstance();

--- a/plugins/rest-change-password/index.php
+++ b/plugins/rest-change-password/index.php
@@ -24,7 +24,7 @@ class RestChangePasswordPlugin extends \RainLoop\Plugins\AbstractPlugin
                 $sFieldOldpassword = \trim($this->Config()->Get('plugin', 'rest_field_oldpassword', ''));
                 $sFieldNewpassword = \trim($this->Config()->Get('plugin', 'rest_field_newpassword', ''));
 
-                if (!empty($sHost) && (!empty($sKey)))
+                if (!empty($sUrl))
                 {
                     include_once __DIR__.'/RestChangePasswordDriver.php';
 


### PR DESCRIPTION
The RestChangePasswordDriver had a few issues and wasn't useable.
This commit fixes these issues.

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>