### PR TITLE
Support dynamic salt lengths in ISPConfig password driver

### DIFF
--- a/plugins/ispconfig-change-password/IspConfigChangePasswordDriver.php
+++ b/plugins/ispconfig-change-password/IspConfigChangePasswordDriver.php
@@ -180,6 +180,12 @@ class IspConfigChangePasswordDriver implements \RainLoop\Providers\ChangePasswor
         return substr($sPasswordHash, 0, strrpos($sPasswordHash, '$'));
     }
 
+    /**
+     * @param string $sHashedPassword
+     * @param string $sClearTextPassword
+     *
+     * @return string|null
+     */
     private function getPasswordHashFromOldPassword($sHashedPassword, $sClearTextPassword)
     {
         $sClearTextPassword = mb_convert_encoding($sClearTextPassword, self::PASSWORD_ENCODING, 'UTF-8');


### PR DESCRIPTION
This fixes the "CouldNotSaveNewPassword" error when changing password via settings for mailboxes created/updated in newer ISPConfig versions.

Additionally:
* Splits logic into smaller methods
* Adds log method to avoid same ifs
* Adds more log output in case of errors
* Updates cryptPassword to behave the same as in ISPConfig (more secure salt generation)
* Fixes some code styles

This should fix:
https://github.com/RainLoop/rainloop-webmail/issues/2072
https://github.com/RainLoop/rainloop-webmail/issues/1946

Should include all fixes according ISPConfig solved in some other way in:
https://github.com/RainLoop/rainloop-webmail/pull/2095

This still doesn't add support for multi server environments:
https://github.com/RainLoop/rainloop-webmail/issues/733

I implemented the code with a PHP language level of 7.0. Everything above is supported.
Wasn't sure if there are any style rules but I did my best to match with the style used in other plugins.

I tested the code with a local environment and on production servers.
The password salt detection is backwards compatible with old passwords using a fixed salt length.
So this shouldn't have any side effects on existing installations.