### PR TITLE
Add support for webpack v5

### DIFF
--- a/webpack.config.builder.js
+++ b/webpack.config.builder.js
@@ -115,7 +115,7 @@ module.exports = function(publicPath, pro, mode) {
 				},
 				{
 					test: /\.css/,
-					loaders: ['style-loader', 'css-loader'],
+					use: ['style-loader', 'css-loader'],
 					include: [devPath]
 				},
 				{


### PR DESCRIPTION
In [1], webpack upstream states that module.rules.loaders was removed.
In [2], the upstream docs state that module.rules.loaders is an alias to
module.rules.use. Therefore, we patch the config file to switch from the
latter to the later.

[1] https://webpack.js.org/blog/2020-10-10-webpack-5-release/
[2] https://v4.webpack.js.org/configuration/module/#ruleloaders

Signed-off-by: Athos Ribeiro <athos.ribeiro@canonical.com>