### PR TITLE
Change reCAPTCHA domain

### DIFF
--- a/plugins/recaptcha/index.php
+++ b/plugins/recaptcha/index.php
@@ -86,7 +86,7 @@ class RecaptchaPlugin extends \RainLoop\Plugins\AbstractPlugin
 			$bResult = false;
 
 			$sResult = $this->Manager()->Actions()->Http()->SendPostRequest(
-				'https://www.google.com/recaptcha/api/siteverify',
+				'https://www.recaptcha.net/recaptcha/api/siteverify',
 				array(
 					'secret' => $this->Config()->Get('plugin', 'private_key', ''),
 					'response' => $this->Manager()->Actions()->GetActionParam('RecaptchaResponse', '')

--- a/plugins/recaptcha/js/recaptcha.js
+++ b/plugins/recaptcha/js/recaptcha.js
@@ -39,7 +39,7 @@
 		{
 			if (!window.grecaptcha && window.rl)
 			{
-				$.getScript('https://www.google.com/recaptcha/api.js?onload=__globalShowRecaptcha&render=explicit&hl=' + window.rl.settingsGet('Language'));
+				$.getScript('https://www.recaptcha.net/recaptcha/api.js?onload=__globalShowRecaptcha&render=explicit&hl=' + window.rl.settingsGet('Language'));
 			}
 			else
 			{


### PR DESCRIPTION
For some reason, the domain www.google.com can't load normally in China, but www.recaptcha.net can.