### PR TITLE
Fix php 8 ,  Fatal error: Cannot redeclare , Deprecated  Creation of dynamic property 

### DIFF
--- a/rainloop/v/0.0.0/app/libraries/MailSo/Base/StreamWrappers/Binary.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Base/StreamWrappers/Binary.php
@@ -67,13 +67,18 @@ class Binary
 	 * @var string
 	 */
 	private $sReadEndBuffer;
-
+	
+	/**
+	 * @var string
+	 */
+	public $context;
+	
 	/**
 	 * @param string $sContentTransferEncoding
 	 * @param bool $bDecode = true
 	 *
 	 * @return string
-	 */
+	 */	
 	public static function GetInlineDecodeOrEncodeFunctionName($sContentTransferEncoding, $bDecode = true)
 	{
 		$sFunctionName = '';

--- a/rainloop/v/0.0.0/app/libraries/MailSo/Base/StreamWrappers/Literal.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Base/StreamWrappers/Literal.php
@@ -42,7 +42,12 @@ class Literal
 	 * @var int
 	 */
 	private $iPos;
-
+	
+	/**
+	 * @var string
+	 */
+	public $context;
+	
 	/**
 	 * @param resource $rStream
 	 * @param int $iLiteralLen

--- a/rainloop/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
+++ b/rainloop/v/0.0.0/app/libraries/MailSo/Imap/ImapClient.php
@@ -88,6 +88,11 @@ class ImapClient extends \MailSo\Net\NetClient
 	public $__FORCE_SELECT_ON_EXAMINE__;
 
 	/**
+	 * @var bool
+	 */
+	private $bResponseBufferChanged;	
+	
+	/**
 	 * @access protected
 	 */
 	protected function __construct()

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Actions.php
@@ -132,6 +132,11 @@ class Actions
 	private $sUpdateAuthToken;
 
 	/**
+	 * @var bool
+	 */
+	private $bIsAjax;
+	
+	/**
 	 * @access private
 	 */
 	private function __construct()

--- a/rainloop/v/0.0.0/app/libraries/RainLoop/Plugins/Manager.php
+++ b/rainloop/v/0.0.0/app/libraries/RainLoop/Plugins/Manager.php
@@ -65,6 +65,11 @@ class Manager
 	private $oLogger;
 
 	/**
+	 * @var array
+	 */
+	private $aAjaxFilters;
+	
+	/**
 	 * @param \RainLoop\Actions $oActions
 	 */
 	public function __construct(\RainLoop\Actions $oActions)


### PR DESCRIPTION
Fix php 8 ,  Fatal error: Cannot redeclare , Deprecated  Creation of dynamic property 


# Fix error code: header injection to attachment files
```
Deprecated</b>:  Creation of dynamic property MailSo\Base\StreamWrappers\Literal::$context is deprecated in <b>/var/www/html/rainloop/rainloop/v/1.17.0/app/libraries/MailSo/Base/StreamWrappers/Literal.php</b> on line <b>65</b><br />

Deprecated</b>:  Creation of dynamic property MailSo\Base\StreamWrappers\Binary::$context is deprecated in <b>/var/www/html/rainloop/rainloop/v/1.17.0/app/libraries/MailSo/Base/StreamWrappers/Binary.php</b> on line <b>242</b><br />
```

![image](https://github.com/RainLoop/rainloop-webmail/assets/1191385/1889f545-4066-4dea-8aed-65b9b09d59fc)